### PR TITLE
Bugfix to handle more than eleven blank nodes correctly 

### DIFF
--- a/__tests__/Termwise.spec.ts
+++ b/__tests__/Termwise.spec.ts
@@ -13,6 +13,8 @@ import {
   expRevealDocument3,
   testSignedDocumentMultiProofs,
   testRevealDocument,
+  expVCDocumentWithLongList,
+  expRevealDocumentWithLongList,
   customLoader
 } from "./__fixtures__";
 
@@ -344,6 +346,21 @@ describe("BbsTermwise2021 and BbsTermwiseSignature2021", () => {
 
     await signDeriveVerifyMulti(
       [{ vc, revealDocument: expRevealDocument, key: expKey1 }],
+      hiddenUris,
+      customLoader,
+      BbsTermwiseSignature2021,
+      BbsTermwiseSignatureProof2021
+    );
+  });
+
+  it("should sign and verify a VC with long list, then derive and verify a proof from it", async () => {
+    const vc = { ...expVCDocumentWithLongList };
+    const revealDocument = { ...expRevealDocumentWithLongList };
+    const key = expKey1;
+    const hiddenUris = ["http://example.org/credentials/1234"];
+
+    await signDeriveVerifyMulti(
+      [{ vc, revealDocument, key }],
       hiddenUris,
       customLoader,
       BbsTermwiseSignature2021,

--- a/__tests__/__fixtures__/data/exp_reveal_document_with_long_list.json
+++ b/__tests__/__fixtures__/data/exp_reveal_document_with_long_list.json
@@ -1,0 +1,15 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://zkp-ld.org/bbs-termwise-2021.jsonld",
+    "https://schema.org"
+  ],
+  "type": [
+    "VerifiableCredential"
+  ],
+  "@explicit": true,
+  "credentialSubject": {
+    "@explicit": true,
+    "freightList": {}
+  }
+}

--- a/__tests__/__fixtures__/data/exp_vc_with_long_list.json
+++ b/__tests__/__fixtures__/data/exp_vc_with_long_list.json
@@ -1,0 +1,63 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://zkp-ld.org/bbs-termwise-2021.jsonld",
+    "https://schema.org"
+  ],
+  "id": "http://example.org/credentials/2/1",
+  "type": "VerifiableCredential",
+  "issuer": "did:example:issuer1",
+  "issuanceDate": "2021-09-01T00:00:00Z",
+  "expirationDate": "2022-09-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:cityA",
+    "type": "Place",
+    "freightList": [
+      {
+        "xxx": "yyy1",
+        "from": "fff1"
+      },
+      {
+        "xxx": "yyy2",
+        "from": "fff2"
+      },
+      {
+        "xxx": "yyy3",
+        "from": "fff3"
+      },
+      {
+        "xxx": "yyy4",
+        "from": "fff4"
+      },
+      {
+        "xxx": "yyy5",
+        "from": "fff5"
+      },
+      {
+        "xxx": "yyy6",
+        "from": "fff6",
+        "to": "ttt6"
+      },
+      {
+        "xxx": "yyy7",
+        "from": "fff7"
+      },
+      {
+        "xxx": "yyy8",
+        "from": "fff8"
+      },
+      {
+        "xxx": "yyy9",
+        "from": "fff9"
+      },
+      {
+        "xxx": "yyy10",
+        "from": "fff10"
+      },
+      {
+        "xxx": "yyy11",
+        "from": "fff11"
+      }
+    ]
+  }
+}

--- a/__tests__/__fixtures__/index.ts
+++ b/__tests__/__fixtures__/index.ts
@@ -57,6 +57,8 @@ import expVCDocumentForRangeProofInvalid from "./data/exp_vc_rangeproof_invalid.
 import expRevealDocumentWithoutRangeProof from "./data/exp_reveal_document_rangeproof0.json";
 import expRevealDocumentForRangeProof from "./data/exp_reveal_document_rangeproof1.json";
 import expRevealDocumentForRangeProof2 from "./data/exp_reveal_document_rangeproof2.json";
+import expVCDocumentWithLongList from "./data/exp_vc_with_long_list.json";
+import expRevealDocumentWithLongList from "./data/exp_reveal_document_with_long_list.json";
 
 export {
   exampleBls12381KeyPair,
@@ -103,5 +105,7 @@ export {
   expVCDocumentForRangeProofInvalid,
   expRevealDocumentWithoutRangeProof,
   expRevealDocumentForRangeProof,
-  expRevealDocumentForRangeProof2
+  expRevealDocumentForRangeProof2,
+  expVCDocumentWithLongList,
+  expRevealDocumentWithLongList
 };

--- a/src/Statement.ts
+++ b/src/Statement.ts
@@ -234,11 +234,13 @@ export class Statement {
     }
     const g = { ...this.graph };
 
-    s.value = s.value.replace(from, to);
-    p.value = p.value.replace(from, to);
-    o.value = o.value.replace(from, to);
+    const exact_replace = (v: string, from: string, to: string): string =>
+      v === from ? to : v;
+    s.value = exact_replace(s.value, from, to);
+    p.value = exact_replace(p.value, from, to);
+    o.value = exact_replace(o.value, from, to);
     if (g) {
-      g.value = g.value.replace(from, to);
+      g.value = exact_replace(g.value, from, to);
     }
 
     return new Statement(undefined, s, p, o, g);


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
-->

## Description

This PR fixes `Statement.replace()` function to correctly handle >=11 blank nodes.

<!--- Describe your changes in detail -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

The `Statement.replace()` function internally used `String.prototype.replace()` function to map a URN-ized blank node label (e.g., `urn:bnid:0:_:c14n0`) to the corresponding pseudonym (e.g., `urn:anon:beb791fe-6152-4a0b-8d28-1448c3cadec5`) to hide the original label, which caused problematic substring-based replacement; for example, if `urn:bnid:0:_:c14n1` is mapped to pseudonym `urn:anon:xxx`, then `urn:bnid:0:_:c14n10` was unintentionally mapped to `urn:anon:xxx0`. We got this issue only when there are more than eleven blank nodes (from c14n0 to c14n10) otherwise there are no substring collisions in blank node identifiers.

<!--- Why is this change required? What problem does it solve? -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
